### PR TITLE
Load WPML Compatibility for Polylang

### DIFF
--- a/inc/class-header-footer-elementor.php
+++ b/inc/class-header-footer-elementor.php
@@ -218,8 +218,8 @@ class Header_Footer_Elementor {
 		// Load Elementor Canvas Compatibility.
 		require_once HFE_DIR . 'inc/class-hfe-elementor-canvas-compat.php';
 
-		// Load WPML Compatibility if WPML is installed and activated.
-		if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+		// Load WPML & Polylang Compatibility if WPML is installed and activated.
+		if ( defined( 'ICL_SITEPRESS_VERSION' ) || defined( 'POLYLANG_BASENAME' ) ) {
 			require_once HFE_DIR . 'inc/compatibility/class-hfe-wpml-compatibility.php';
 		}
 


### PR DESCRIPTION
To increase compatibility, we support lots of WPML constant / hook and functions
https://polylang.pro/doc/wpml-api/
Loading your WPML compatibility  seems  to work with Polylang

### Description
Prajakta from Brainstorm Force team contacted us on support@polylang.pro to improve compatibility between our both plugins.

### Types of changes
My code load the WPML compatibilty when Polylang is activated.

### How has this been tested?
I activated on Polylang Settings the CPT Elementor - Header Footer & Blocks Template.
I created a cutom header for 2 languages
I visited the website in each language to check the header change when I switch the language

### Checklist:
- [x] My code is tested
- [x] My code passes the PHPCS tests
- [x] My code follows accessibility standards <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/ -->
- [x] My code has proper inline documentation <!-- Guidelines: https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/ -->
- [x] I've included any necessary tests <!-- if applicable -->
- [x] I've included developer documentation <!-- if applicable -->
- [x] I've added proper labels to this pull request <!-- if applicable -->
